### PR TITLE
inventory.show doesn't block waiting for an IP

### DIFF
--- a/vlab_inventory_api/lib/worker/vmware.py
+++ b/vlab_inventory_api/lib/worker/vmware.py
@@ -22,7 +22,7 @@ def show_inventory(username):
         folder = vcenter.get_by_name(name=username, vimtype=vim.Folder)
         vms = {}
         for entity in folder.childEntity:
-            info = virtual_machine.get_info(vcenter, entity)
+            info = virtual_machine.get_info(vcenter, entity, ensure_ip=False)
             vms[entity.name] = info
     return vms
 


### PR DESCRIPTION
Turns out, if a few people have some OneFS machines in their inventory, and all start asking to "show me what's in my lab," the whole dang service will get DoS because of this gem!